### PR TITLE
Add target_billing_account_id option in secret data

### DIFF
--- a/src/cloudforet/cost_analysis/manager/job_manager.py
+++ b/src/cloudforet/cost_analysis/manager/job_manager.py
@@ -33,8 +33,13 @@ class JobManager(BaseManager):
         self._check_target_project_id_in_secret_data(secret_data)
 
         billing_dataset = self._get_billing_dataset_from_secret_data(secret_data)
-        billing_info = self.cloud_billing_connector.get_billing_info()
-        prefix, self.billing_account_id = billing_info['billingAccountName'].split('/')
+
+        if secret_data.get('target_billing_account_id'):
+            self.billing_account_id = secret_data['target_billing_account_id']
+        else:
+            billing_info = self.cloud_billing_connector.get_billing_info()
+            prefix, self.billing_account_id = billing_info['billingAccountName'].split('/')
+
         target_project_ids = self._get_target_project_ids(secret_data['target_project_id'])
 
         secret_type = options.get('secret_type', SECRET_TYPE_DEFAULT)
@@ -110,7 +115,7 @@ class JobManager(BaseManager):
             'task_options': {
                 'start': start_date,
                 'billing_dataset': billing_dataset,
-                'sub_billing_account': self.billing_account_id,
+                'billing_account_id': self.billing_account_id,
                 'target_project_id': target_project_id
             }
         }

--- a/src/cloudforet/cost_analysis/model/job_model.py
+++ b/src/cloudforet/cost_analysis/model/job_model.py
@@ -8,7 +8,7 @@ __all__ = ['Tasks']
 class TaskOptions(Model):
     start = StringType(required=True)
     billing_dataset = StringType()
-    sub_billing_account = StringType(default=None)
+    billing_account_id = StringType(default=None)
     target_project_id = StringType()
 
 


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [X] Improvement
- [ ] Refactor
- [ ] etc

### Description
An option was added to handle the case where the billing data accumulated in BigQuery is a different project_id than BigQuery's project_id, that is, the billing_account_id is different.